### PR TITLE
Update CI to support moved vendor directory

### DIFF
--- a/runCI/executeCI.ps1
+++ b/runCI/executeCI.ps1
@@ -679,6 +679,7 @@ Try {
             $sourceBaseLocation="$env:SOURCES_DRIVE`:\$env:SOURCES_SUBDIR"
             $pathUpdate="`$env:PATH='$env:TEMP\binary;'+`$env:PATH;"
         }
+        $sourceBaseLocation += "\src\github.com\docker\docker"
 
         # Jumping through hoop craziness. Don't ask! Parameter parsing, powershell, go, parameters starting "-check."... :(
         # Just dump it to a file and pass through in a volume with the binaries when in a container, or run locally otherwise
@@ -704,10 +705,18 @@ Try {
             `$cliArgs+=`"-check.timeout=240m`"; `
             `$cliArgs+=`"-test.timeout=360m`"; `
             `$cliArgs+=`"-tags autogen`"; `
-            cd $sourceBaseLocation\src\github.com\docker\docker\integration-cli;         `
+            if (Test-Path $sourceBaseLocation\cmd\integration-cli) { `
+                cd $sourceBaseLocation\cmd\integration-cli; `
+                cmd /c mklink /j  ..\vendor\github.com\docker\docker $sourceBaseLocation `
+            } else { `
+                cd $sourceBaseLocation\integration-cli `
+            }; `
             echo `$cliArgs; `
             `$p=Start-Process -Wait -NoNewWindow -FilePath go -ArgumentList `$cliArgs  -PassThru; `
-             exit `$p.ExitCode `
+            if (Test-Path $sourceBaseLocation\cmd\vendor\github.com\docker\docker) { `
+                cmd /c rd $sourceBaseLocation\cmd\vendor\github.com\docker\docker `
+            }; `
+            exit `$p.ExitCode `
            "
         $c | Out-File -Force "$env:TEMP\binary\runIntegrationCLI.ps1"
 


### PR DESCRIPTION
Use cmd to create and remove a directory junction, with mklink and rd,
respectively, due to two PowerShell issues.

When creating a junction with New-Item, PowerShell converts the target
path to an unexpected NT object form, where “C:\gopath” becomes
“\??\C:\gopath”. This is generally resolved successfully, but the
Go runtime panics in its symlink evaluation code.

PowerShell New-Item creates symbolic links with an expected Win32 path,
addressing the first issue, but Remove-Item fails to remove them, even
with -Force and -Recurse. However, Remove-Item can successfully remove
junctions if those two flags are passed.

Signed-off-by: John Stephens <johnstep@docker.com>