### PR TITLE
Print out environment variables by piping them to Out-String.

### DIFF
--- a/runCI/executeCI.ps1
+++ b/runCI/executeCI.ps1
@@ -219,7 +219,8 @@ Try {
     Write-Host -ForegroundColor green "INFO: Branch:$Branch Build:$WindowsBuild"
 
     # List the environment variables
-    Get-ChildItem Env:
+    Write-Host -ForegroundColor green "INFO: Environment variables:"
+    Get-ChildItem Env: | Out-String
 
     # PR
     if (-not ($env:PR -eq $Null)) { echo "INFO: PR#$env:PR (https://github.com/docker/docker/pull/$env:PR)" }


### PR DESCRIPTION
This is a fix for issue #15 that I filed. Piping to Out-String is enough to make our internal PowerShell hosting platform happy.